### PR TITLE
compatibility fix for underground biomes

### DIFF
--- a/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockKelp.java
+++ b/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockKelp.java
@@ -85,6 +85,12 @@ public class BlockKelp extends BlockWaterloggedPlant implements IGrowable
     }
 
     @Override
+    public net.minecraftforge.common.EnumPlantType getPlantType(IBlockAccess world, BlockPos pos)
+    {
+        return net.minecraftforge.common.EnumPlantType.Water;
+    }
+
+    @Override
     protected boolean canSustainBush(@Nonnull IBlockState state) {
         if(isEqualTo(state.getBlock(), Blocks.MAGMA)) return false;
         return isEqualTo(state.getBlock(), this) || state.isTopSolid();

--- a/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockSeaPickle.java
+++ b/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockSeaPickle.java
@@ -92,6 +92,12 @@ public class BlockSeaPickle extends BlockBush implements IGrowable, IFluidloggab
         return aabb[state.getValue(PICKLES)];
     }
 
+    @Override
+    public net.minecraftforge.common.EnumPlantType getPlantType(IBlockAccess world, BlockPos pos)
+    {
+        return net.minecraftforge.common.EnumPlantType.Water;
+    }
+
     @Nonnull
     @Override
     public AxisAlignedBB getCollisionBoundingBox(@Nonnull IBlockState blockState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {

--- a/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockSeagrass.java
+++ b/src/main/java/git/jbredwards/subaquatic/mod/common/block/BlockSeagrass.java
@@ -94,6 +94,12 @@ public class BlockSeagrass extends BlockWaterloggedPlant implements IShearable, 
     }
 
     @Override
+    public net.minecraftforge.common.EnumPlantType getPlantType(IBlockAccess world, BlockPos pos)
+    {
+        return net.minecraftforge.common.EnumPlantType.Water;
+    }
+
+    @Override
     protected boolean canSustainBush(@Nonnull IBlockState state) {
         if(isEqualTo(state.getBlock(), Blocks.MAGMA)) return false;
         else if(isEqualTo(state.getBlock(), this)) return state.getValue(TYPE) != Type.TOP;


### PR DESCRIPTION
adding a plant type for kelp, seagrass and sea pickle allows them to be placed and grow on underground biomes variants of terrain blocks